### PR TITLE
解答選択肢ページのチェック

### DIFF
--- a/frontend/flashreading/src/App.tsx
+++ b/frontend/flashreading/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState } from "react";
+import reactLogo from "./assets/react.svg";
+import viteLogo from "/vite.svg";
+import "./App.css";
+import UserAnswer from "./components/UserAnswer";
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(0);
 
   return (
     <>
@@ -24,12 +25,13 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
+        <UserAnswer correctWords={["apple", "banana"]} />
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/flashreading/src/components/UserAnswer.css
+++ b/frontend/flashreading/src/components/UserAnswer.css
@@ -1,0 +1,97 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  gap: 0;
+  flex-direction: column;
+}
+
+.container-column {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  gap: 0;
+}
+
+.big-background {
+  width: 1200px; /* 大きな四角の幅 */
+  height: 500px; /* 大きな四角の高さ */
+  background-color: #ccc;
+  position: relative;
+  margin-bottom: 0;
+}
+
+.big-squares {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.big-square {
+  width: 100%; /* 小さな四角の幅 */
+  height: 100%; /* 小さな四角の高さ */
+  background-color: #999;
+  border: none;
+  margin: 5px; /* 四角同士の間隔 */
+  cursor: pointer;
+  outline: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white; /* テキストの色 */
+  font-size: 48px; /* テキストのサイズ */
+}
+
+.small-background {
+  width: 1200px; /* 大きな四角の幅 */
+  height: 200px; /* 大きな四角の高さ */
+  background-color: #ccc;
+  position: relative;
+  margin-top: 0;
+}
+
+.small-squares {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.small-square {
+  width: 100%; /* 小さな四角の幅 */
+  height: 100%; /* 小さな四角の高さ */
+  background-color: #999;
+  border: 4px solid black;
+  margin: 5px; /* 四角同士の間隔 */
+  cursor: pointer;
+  outline: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white; /* テキストの色 */
+  font-size: 14px; /* テキストのサイズ */
+}
+
+.small-square:hover {
+  background-color: #777;
+}

--- a/frontend/flashreading/src/components/UserAnswer.tsx
+++ b/frontend/flashreading/src/components/UserAnswer.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import "./UserAnswer.css";
+interface UserAnswerProps {
+  correctWords: string[]; // 赤く表示する単語群　　App.tsxからpropsとしてもらう
+}
+const UserAnswer: React.FC<UserAnswerProps> = ({ correctWords }) => {
+  const [currentWordIndex, setCurrentWordIndex] = useState(0);
+  const highlightText = (text: string, word: string) => {
+    const regex = new RegExp(`(${word})`, "gi");
+    const parts = text.split(regex);
+    return parts.map((part, index) =>
+      word.toLowerCase() === part.toLowerCase() ? (
+        <span key={index} style={{ color: "red" }}>
+          {part}
+        </span>
+      ) : (
+        <span key={index}>{part}</span>
+      )
+    );
+  };
+  //const 関数名 = (引数) => {関数の処理;};
+  const handleNextWord = () => {
+    setCurrentWordIndex((prevIndex) => prevIndex + 1);
+  };
+  // correctWords の全てが使われたらコンポーネントを非表示にする
+  if (currentWordIndex >= correctWords.length) {
+    return null;
+  }
+
+  return (
+    <div className="container-column">
+      <div className="big-background">
+        <div className="big-squares">
+          <div className="big-square">
+            {highlightText("This is a banana.", correctWords[currentWordIndex])}
+          </div>
+        </div>
+      </div>
+      <div className="small-background">
+        <div className="small-squares">
+          <button className="small-square" onClick={handleNextWord}>
+            りんご
+          </button>
+          <button className="small-square" onClick={handleNextWord}>
+            ブドウ
+          </button>
+          <button className="small-square" onClick={handleNextWord}>
+            みかん
+          </button>
+          <button className="small-square" onClick={handleNextWord}>
+            いちご
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserAnswer;
+
+//残りの実装する機能
+//correctwordsをchatgptに渡し，問題文と選択肢を作ってもらう（他の人が作ったコンポーネントからもらうかも）
+//赤い単語の前に空白を正しく入れる
+//このファイルに書くことじゃないが，App.tcxでpropsとして入力単語をもらえるようにする
+//ボタンが押された時，正解だったかどうかを保存する
+//問題が終了した後，解答ページに移る（正解だったかどうかの情報を渡す）


### PR DESCRIPTION
解答を選択するページが大体終わったのでチェックお願いします
//残りの実装する機能
//correctwordsをchatgptに渡し，問題文と選択肢を作ってもらう（他の人が作ったコンポーネントからもらうかも）
//赤い単語の前に空白を正しく入れる
//このファイルに書くことじゃないが，App.tcxでpropsとして入力単語をもらえるようにする
//ボタンが押された時，正解だったかどうかを保存する
//問題が終了した後，解答ページに移る（正解だったかどうかの情報を渡す）